### PR TITLE
fix: 게시글 조회 시 timezone 수정

### DIFF
--- a/src/app/api/post/route.ts
+++ b/src/app/api/post/route.ts
@@ -4,6 +4,7 @@ import { getAuthenticatedUser } from '@/actions/action';
 import { addPost } from '@/service/supa-post';
 import { uploadFileToS3 } from '@/service/s3-upload';
 import { NextRequest, NextResponse } from 'next/server';
+import { getDateYYYYMMDDWithDash } from '@/utils/utils';
 
 export async function POST(req: NextRequest) {
   const user = await getAuthenticatedUser();
@@ -30,7 +31,6 @@ export async function POST(req: NextRequest) {
     authorId: user.id,
     caption: text,
     imageKey: publicUrl,
-    createdAt: new Date().toISOString(),
   };
 
   return addPost(param)

--- a/src/service/supa-post.ts
+++ b/src/service/supa-post.ts
@@ -9,8 +9,8 @@ export const getPosts = async (date: string) => {
   const { data: posts, error } = await client
     .from('posts_enriched')
     .select('*')
-    .gte('created_at', `${date}T00:00:00.000Z`)
-    .lte('created_at', `${date}T23:59:59.999Z`)
+    .gte('created_at', `${date}T00:00:00.000`)
+    .lte('created_at', `${date}T23:59:59.999`)
     .order('created_at', { ascending: false });
 
   if (error) throw error;
@@ -58,17 +58,19 @@ export const getPostComments = async (id: string) => {
 };
 
 export const addPost = async (
-  post: Omit<SupaPost, 'comments' | 'id' | 'updatedAt' | 'author'>,
+  post: Omit<
+    SupaPost,
+    'comments' | 'id' | 'createdAt' | 'updatedAt' | 'author'
+  >,
 ) => {
   const client = await serverSupabase();
-  const { authorId, caption, imageKey, createdAt } = post;
+  const { authorId, caption, imageKey } = post;
   const { data, error } = await client
     .from('posts')
     .insert({
       author_id: authorId,
       caption,
       image_key: imageKey,
-      created_at: createdAt,
     })
     .select()
     .single();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 날짜별 게시물 목록이 사용자의 현지 시간대 기준으로 정확히 표시되도록 시간 필터를 조정했습니다. 이전 UTC 기준으로 인해 일부 게시물이 다른 날짜로 분류되던 문제를 해소했습니다.
  * 게시물 작성 시 생성 시간이 데이터베이스에서 자동으로 기록되도록 개선하여 타임스탬프 누락/불일치 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->